### PR TITLE
Support for Haskell, Scala, and Ruby for judge system

### DIFF
--- a/www/judge/languages/hs.py
+++ b/www/judge/languages/hs.py
@@ -1,0 +1,31 @@
+import subprocess
+
+def system(cmd):
+    return subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE).communicate()
+
+LANGUAGE = "Haskell"
+EXT = "hs"
+VERSION = system(["ghc", "--version"])[0].split("\n")[0]
+ADDITIONAL_FILES = []
+
+def setup(sandbox, source_code):
+    sandbox.write_file(source_code, "Main.hs")
+    compiled = sandbox.run("ghc --make -O2 Main", stdout=".stdout",
+                           stderr=".stderr", time_limit=10)
+    if compiled.split()[0] != "OK":
+        return {"status": "error",
+                "message": sandbox.read_file(".stderr")}
+    #sandbox.run("rm submission.cpp .stdin .stderr")
+    print('haskell setup')
+    return {"status": "ok"}
+
+def run(sandbox, input_file, time_limit, memory_limit):
+    result = sandbox.run("./Main", stdin=input_file, time_limit=time_limit,
+                         override_memory_limit=memory_limit,
+                         stdout=".stdout", stderr=".stderr")
+    toks = result.split()
+    if toks[0] != "OK":
+        return {"status": "fail", "message": result, "verdict": toks[0] }
+    print('haskell run')
+    return {"status": "ok", "time": toks[1], "memory": toks[2], "output": ".stdout"}

--- a/www/judge/languages/rb.py
+++ b/www/judge/languages/rb.py
@@ -1,0 +1,23 @@
+import subprocess
+
+def system(cmd):
+    return subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE).communicate()
+
+LANGUAGE = "Ruby"
+EXT = "rb"
+VERSION = system(["ruby", "--version"])[0]
+ADDITIONAL_FILES = []
+
+def setup(sandbox, source_code):
+    sandbox.write_file(source_code, "submission.rb")
+    return {"status": "ok"}
+
+def run(sandbox, input_file, time_limit, memory_limit):
+    result = sandbox.run("ruby submission.rb", stdin=input_file, time_limit=time_limit,
+                         override_memory_limit=memory_limit,
+                         stdout=".stdout", stderr=".stderr")
+    toks = result.split()
+    if toks[0] != "OK":
+        return {"status": "fail", "message": result, "verdict": toks[0] }
+    return {"status": "ok", "time": toks[1], "memory": toks[2], "output": ".stdout"}

--- a/www/judge/languages/scala.py
+++ b/www/judge/languages/scala.py
@@ -1,0 +1,30 @@
+import subprocess
+
+def system(cmd):
+    return subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE).communicate()
+
+LANGUAGE = "Scala"
+EXT = "scala"
+VERSION = system(["scala", "-version"])[0].split("\n")[0]
+ADDITIONAL_FILES = []
+
+def setup(sandbox, source_code):
+    sandbox.write_file(source_code, "Main.scala")
+    compiled = sandbox.run("scalac Main.scala", stdout=".stdout",
+                           stderr=".stderr", time_limit=10)
+    if compiled.split()[0] != "OK":
+        return {"status": "error",
+                "message": ("MONITOR:\n" + compiled + "\n" +
+                            "STDERR:\n" + sandbox.read_file(".stderr") + "\n" +
+                            "STDOUT:\n" + sandbox.read_file(".stdout"))}
+    return {"status": "ok"}
+
+def run(sandbox, input_file, time_limit, memory_limit):
+    result = sandbox.run("scala Main", stdin=input_file, time_limit=time_limit,
+                         override_memory_limit=memory_limit,
+                         stdout=".stdout", stderr=".stderr")
+    toks = result.split()
+    if toks[0] != "OK":
+        return {"status": "fail", "message": result, "verdict": toks[0] }
+    return {"status": "ok", "time": toks[1], "memory": toks[2], "output": ".stdout"}

--- a/www/settings.py
+++ b/www/settings.py
@@ -61,7 +61,7 @@ MEDIA_ROOT = j("media")
 # Examples: "http://media.lawrence.com/media/", "http://example.com/media/"
 #MEDIA_URL = '/media/'
 # set for development: reset for prod
-MEDIA_URL = "http://127.0.0.1:8000/media/"
+MEDIA_URL = "http://0.0.0.0:8000/media/"
 
 # Absolute path to the directory static files should be collected to.
 # Don't put anything in this directory yourself; store your static files
@@ -209,7 +209,7 @@ JUDGE_SETTINGS = {
     "WORKDIR": j("judge/work"),
     "USER": "runner",
     "FILESYSTEMSIZE": 64 * 1024,
-    "MINMEMORYSIZE": 128 * 1024,
+    "MINMEMORYSIZE": 256 * 1024,
 }
 
 # PAGINATION SETTINGS


### PR DESCRIPTION
See the proof of concept at: http://147.46.242.9:8000/judge/submission/recent/

1) This patch requires the system to have compilers and interpreters.
Install ghc, scala, and ruby.

sudo apt-get install haskell-platform scala ruby

2) Scala compiler needs a lot of memory, so that minimum required
memory is grown from 128MB to 256MB for judge system (settings.py).

3) Default media location is changed from 127.0.0.1 to 0.0.0.0;
this change enables to develop on remote machine (settings.py).
