### PR TITLE
refs #470, 링크 변환을 markdown 변환보다 우선하도록 수정.

### DIFF
--- a/www/libs/common/djangoutils.py
+++ b/www/libs/common/djangoutils.py
@@ -154,6 +154,6 @@ def render_text(text):
     text = substitute_spoiler_tags(text)
     text = highlight_code_section(text)
     text = urlize(text)
-    text = md.convert(text)
     text = link_to_entities(text)
+    text = md.convert(text)
     return text


### PR DESCRIPTION
테이블 안에서 [[text|link]] 문법이 충돌하던 문제를 수정하기 위함이다.
