### PR TITLE
Fixes #40: 로그인 버튼에 "next" 파라미터 추가

### DIFF
--- a/www/templates/base.html
+++ b/www/templates/base.html
@@ -73,7 +73,12 @@
 						<div>
 							<em class="kor">로그인하세요.</em>
 							<ul>
-								<li><a class="button-link" href="{% url auth_login %}" title="로그인" rel="tooltip">sign in</a></li>
+								{% url auth_login as auth_login_url %}
+								{% if request.path == auth_login_url %}
+								<li><a class="button-link" href="{{ request.get_full_path }}" title="로그인" rel="tooltip">sign in</a></li>
+								{% else %}
+								<li><a class="button-link" href="{{ auth_login_url }}?next={{ request.get_full_path|urlencode }}" title="로그인" rel="tooltip">sign in</a></li>
+								{% endif %}
 								<li><a class="button-link" href="{% url registration_register %}" title="회원 가입" rel="tooltip">sign up</a></li>
 							</ul>
 						</div>


### PR DESCRIPTION
다음과 같이 동작합니다
- 일반적인 페이지에서: 로그인 버튼을 누르면 로그인 후 해당 페이지로 되돌아옵니다.
- get parameter가 있을 때: next는 get parameter의 url encoded가 들어가고, 잘 동작합니다.
- 로그인 페이지에서 로그인 버튼을 누를 때: parameter를 유지한 상태로 현재 페이지를 그대로 reloading 하는 것처럼 동작합니다.
