### PR TITLE
build 와 run 분리

### DIFF
--- a/www/judge/languages/go.py
+++ b/www/judge/languages/go.py
@@ -11,10 +11,15 @@ ADDITIONAL_FILES = []
 
 def setup(sandbox, source_code):
     sandbox.write_file(source_code, "submission.go")
+    compiled = sandbox.run("go build -o a.out submission.go", stdout=".stdout",
+                           stderr=".stderr", time_limit=10)
+    if compiled.split()[0] != "OK":
+        return {"status": "error",
+                "message": sandbox.read_file(".stderr")}
     return {"status": "ok"}
 
 def run(sandbox, input_file, time_limit, memory_limit):
-    result = sandbox.run("go run submission.go", stdin=input_file, time_limit=time_limit,
+    result = sandbox.run("./a.out", stdin=input_file, time_limit=time_limit,
                          override_memory_limit=memory_limit,
                          stdout=".stdout", stderr=".stderr")
     toks = result.split()


### PR DESCRIPTION
go.py run 함수에서 go run으로 빌드와 실행을 같이 하니까 실행시간에 모두 그게 포함되어 실행시간이 기대했던 것보다 너무 느리게 측정되는 것 같습니다. 그래서 C++ 모듈처럼 go build로 실행파일을 먼저 만들고 그 파일(a.out)을 실행하는 것으로 바꿔봤습니다.
