### PR TITLE
Add an experimental D language support

### DIFF
--- a/www/judge/languages/d.py
+++ b/www/judge/languages/d.py
@@ -1,0 +1,28 @@
+import subprocess
+
+def system(cmd):
+    return subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE).communicate()
+
+LANGUAGE = "D"
+EXT = "d"
+VERSION = system(["gdc", "--version"])[0].split("\n")[0]
+ADDITIONAL_FILES = []
+
+def setup(sandbox, source_code):
+    sandbox.write_file(source_code, "submission.d")
+    compiled = sandbox.run("gdc -O submission.d", stdout=".stdout",
+                           stderr=".stderr", time_limit=10)
+    if compiled.split()[0] != "OK":
+        return {"status": "error",
+                "message": sandbox.read_file(".stderr")}
+    return {"status": "ok"}
+
+def run(sandbox, input_file, time_limit, memory_limit):
+    result = sandbox.run("./a.out", stdin=input_file, time_limit=time_limit,
+                         override_memory_limit=memory_limit,
+                         stdout=".stdout", stderr=".stderr")
+    toks = result.split()
+    if toks[0] != "OK":
+        return {"status": "fail", "message": result, "verdict": toks[0] }
+    return {"status": "ok", "time": toks[1], "memory": toks[2], "output": ".stdout"}


### PR DESCRIPTION
http://algospot.com/forum/read/2287/

GNU D Compiler (gdc) 를 사용하는 저지 모듈의 d language 구현입니다.
현재 컴파일 옵션은 gdc -O 정도로 해봤는데 (gdc-4.6 on 12.04), HELLOWORLD 문제풀이 수준은 잘 동작하는 것 같네요.
- [x] 모듈 구현
- [ ] algospot 서버에 gdc 설치해야함
- [ ] 위키 페이지에 D 언어 예제 코드 추가
