### PR TITLE
Added Python3 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ www/judge/tmp
 www/judge/lxc.log
 
 www_static/
+
+*.iml
+.idea/
+atlassian-ide-plugin.xml

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@
 
 1. 채점 서버에 문제가 있을 경우 다음 커맨드를 통해 VM의 채점 서버를 중단하고, 채점 서버를 콘솔 모드로 돌리면서 채점 서버의 로그를 볼 수 있다.
 
-		$ make celeryd-stop
-		$ make celeryd
+		$ make stop-celeryd
+		$ make celeryd-console
 
 ## 커밋하기
 

--- a/ansible/single_box.yml
+++ b/ansible/single_box.yml
@@ -27,6 +27,7 @@
   - ruby
   - luajit
   - pypy
+  - python3
 
 - name: "install pip"
   sudo: yes

--- a/www/judge/languages/py3.py
+++ b/www/judge/languages/py3.py
@@ -1,0 +1,26 @@
+import subprocess
+
+
+def system(cmd):
+    return subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE).communicate()
+
+LANGUAGE = "Python 3"
+EXT = "py3"
+VERSION = system(["python3", "--version"])[0].split('\n')[0]
+ADDITIONAL_FILES = []
+
+
+def setup(sandbox, source_code):
+    sandbox.write_file(source_code, "submission.py")
+    return {"status": "ok"}
+
+
+def run(sandbox, input_file, time_limit, memory_limit):
+    result = sandbox.run("python3 submission.py", stdin=input_file, time_limit=time_limit,
+                         memory_limit=memory_limit,
+                         stdout=".stdout", stderr=".stderr")
+    toks = result.split()
+    if toks[0] != "OK":
+        return {"status": "fail", "message": result, "verdict": toks[0] }
+    return {"status": "ok", "time": toks[1], "memory": toks[2], "output": ".stdout"}

--- a/www/judge/templates/problem/submit.html
+++ b/www/judge/templates/problem/submit.html
@@ -44,7 +44,8 @@
 			var mapping_to_ace = {
 				java: 'java',
 				scala: 'scala',
-				// no haskell T_T
+                hs: 'haskell',
+                py3: 'python',
 				py: 'python',
 				js: 'javascript',
 				rb: 'ruby',


### PR DESCRIPTION
1. Python3 언어를 지원하도록 변경했습니다. #35
2. Haskell 언어의 syntax highlight 기능을 추가했습니다.
3. README.md 에서 채점서버를 콘솔로 돌리는 방법이 잘못되어 있어서 이를 수정했습니다.
4. 추가로 PyCharm에 대한 gitignore 설정을 추가했습니다.

알고리즘을 공부를 시작해보려 알고스팟에 가입했는데, 파이썬 3가 없길래 추가해봤습니다 ㅎㅎ;  추가로 코드를 보다보니 README.md의 잘못된 부분을 발견하게 되었고요. 또 찾아보니 ace가 haskell을 지원하더라고요. 그래서 python3를 추가하는 김에 haskell도 ace에 추가해서 sytax highlight 되도록 설정했습니다. 코드를 보다보니 주로 다들 vim으로 작업하시는 것 같아서 조심스러웠는데... 보다 원활한 코드 참여를 위해 PyCharm에 대한 gitignore를 추가하는 편이 좋을 것 같아서 조심스레 추가해봤습니다. 

앞으로 알고스팟에도, 또 깃헙 저장소에도 자주 들락날락 거리도록 하겠습니다. 잘부탁드립니다 :)
 