### PR TITLE
gcc/g++ 컴파일 플래그에 NDEBUG 추가.

### DIFF
--- a/www/judge/languages/c11.py
+++ b/www/judge/languages/c11.py
@@ -13,7 +13,7 @@ ADDITIONAL_FILES = []
 
 def setup(sandbox, source_code):
     sandbox.write_file(source_code, "submission.c")
-    compiled = sandbox.run("gcc -O3 submission.c -pedantic-errors -lm -std=c11", stdout=".stdout",
+    compiled = sandbox.run("gcc -O3 submission.c -pedantic-errors -lm -std=c11 -DNDEBUG", stdout=".stdout",
                            stderr=".stderr", time_limit=10,
                            memory_limit=COMPILE_MEMORY_LIMIT)
     if compiled.split()[0] != "OK":

--- a/www/judge/languages/cpp.py
+++ b/www/judge/languages/cpp.py
@@ -13,7 +13,7 @@ ADDITIONAL_FILES = []
 
 def setup(sandbox, source_code):
     sandbox.write_file(source_code, "submission.cpp")
-    compiled = sandbox.run("g++ -O3 submission.cpp -pedantic-errors --std=c++0x", stdout=".stdout",
+    compiled = sandbox.run("g++ -O3 submission.cpp -pedantic-errors --std=c++0x -DNDEBUG", stdout=".stdout",
                            stderr=".stderr", time_limit=10,
                            memory_limit=COMPILE_MEMORY_LIMIT)
     if compiled.split()[0] != "OK":


### PR DESCRIPTION
실제 코드 작성에 있어서 assert 구문을 사용하는 것은 가독성 있는 코드를 만들고, 코드가 하고자 하는 바를 명시적으로 보여주기 때문에 가독성 있는 코드를 만들기 위해 자주 사용됩니다.

하지만 현재의 연산 시간을 중요시하는 PS의 특성 상 알고스팟에서는 assert를 이용해서 조건 체크하는 것이 비용이 되기 때문에 assert를 사용하는 것은 언제나 손해를 보게 합니다.
이런 상황을 막고자 컴파일 옵션에 NDEBUG를 추가할 것을 제안합니다.