### PR TITLE
자바의 메모리 제한 정책 개선

### DIFF
--- a/www/judge/languages/java.py
+++ b/www/judge/languages/java.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import subprocess
 from django.conf import settings
 
@@ -24,9 +25,12 @@ def setup(sandbox, source_code):
     return {"status": "ok"}
 
 def run(sandbox, input_file, time_limit, memory_limit):
-    result = sandbox.run("java -Xmx%dK -Xms%dK Main" % (memory_limit, memory_limit), 
+    # 크기를 예측하기 어려윤 JVM의 non-heap 메모리 영역을 확보해 주기 위해 sandbox 의 메모리 제한을 충분히 크게 할당한다.
+    # 문제의 메모리 제한 조건은 java 의 -Xmx 옵션으로 heap 영역에만 적용되는 셈인데, 충분히 납득할 만 하다고 본다.
+    max_non_heap_size = 65536
+    result = sandbox.run("java -Xmx%dK -Xms%dK Main" % (memory_limit, memory_limit),
                          stdin=input_file, time_limit=time_limit,
-                         memory_limit=memory_limit,
+                         memory_limit=memory_limit + max_non_heap_size,
                          stdout=".stdout", stderr=".stderr")
     toks = result.split()
     if toks[0] != "OK":


### PR DESCRIPTION
자바에서 BigInteger 를 사용해야 하는 문제처럼 메모리를 매우 빈번하게 할당/해제할 때, 실제로 메모리를 많이 쓰는 코드가 아니더라도 MLE 로 판정될 수 있습니다. 이걸 고치고자 합니다.

간단한 코드를 예를 들면, 다음 코드가 MLE 를 발생시킵니다.
서밋은 - https://algospot.com/judge/submission/detail/452479 (HELLOWORLD)

```
public class Main {
    private static int[] holdsOnlyOneArray;
    public static void main(String[] args) {
        for (int i = 0; i < 100; i++)
            holdsOnlyOneArray = new int[1024 * 1024];
    }
}
```

위 코드가 MLE 가 발생한 이유는 이렇습니다.

- 저지에서 java 실행 옵션 -Xmx 로 문제의 메모리 제한을 줍니다.
- 자바는 GC를 하지만, -Xmx 옵션으로 준 크기를 충분히 활용합니다. 일단은 거의 다 쓴다고 봐야합니다.
- 자바는 두가지 메모리 영역이 있습니다. heap, non-heap. 그러나 -Xmx 는 heap 영역에 대한 크기를 제한할 뿐입니다.
- 자바는 간단한 코드도 non-heap 영역으로 수십MB 정도로 상당히 사용합니다.
- 이런 상황에서 여유분으로 주는 10MB 를 넘어서고, sandbox 의 모니터링이 MLE 로 판단합니다.

예를 들어 위의 서밋에 대한 실행 도중에 heap 64MB + non-heap 20MB 가 된다면 MLE 가 됩니다.

몇가지 해결책을 생각해 봤으나, 여기서는 자바일 때만 사실상 sandbox 의 메모리 제한을 없애는 방법을 썼습니다.
정황상 non-heap 영역은 문제를 푸는데 사용한다고 보기는 어렵습니다.
heap 영역의 제한으로 충분하다고 본 방법입니다.

이 방법이 아니더라도 위의 서밋이 “오답” 으로 나오게 수정이 되길 바랍니다 ㅠ