### PR TITLE
make init 실패 수정

### DIFF
--- a/www/static/js/ace
+++ b/www/static/js/ace
@@ -1,1 +1,0 @@
-../../../ace-builds/src-min


### PR DESCRIPTION
collectstatic 단계에서 복사 중 실패하고 있었음.
ace 제거 중 남아있던 깨진 심볼릭 링크가 원인.