### PR TITLE
add link to accepted submissions in the profile page

### DIFF
--- a/www/base/templates/user_profile.html
+++ b/www/base/templates/user_profile.html
@@ -63,8 +63,8 @@
 							({% percentage failed_problem_count attempted_problem_count %}%)</a>
 					</li>
 					<li class="submissions"><a href="{% url "judge-submission-recent" %}?user={{ profile_user.username }}">{{ profile_user.get_profile.submissions }}</a></li>
-					<li class="accepted">{{ profile_user.get_profile.accepted }}
-						({% percentage profile_user.get_profile.accepted profile_user.get_profile.submissions %}%)
+					<li class="accepted"><a href="{%  url "judge-submission-recent" %}?user={{ profile_user.username }}&state={{ submission_accepted_constant }}"> {{ profile_user.get_profile.accepted }}
+						({% percentage profile_user.get_profile.accepted profile_user.get_profile.submissions %}%)</a>
 					</li>
 				</ul>
 			</li>

--- a/www/base/views.py
+++ b/www/base/views.py
@@ -118,6 +118,7 @@ def get_profile(request, user):
                    "failed_problem_count": failed_problem_count,
                    "not_attempted_problem_count": all_problem_count - attempted_problem_count,
                    "submission_chart_url": submission_chart,
+                   "submission_accepted_constant": Submission.ACCEPTED,
                    "category_chart_url": category_chart,
                    "actions": actions,
                    "oj_rank": rank+1,


### PR DESCRIPTION
안녕하세요 알고스팟을 애용하고 있는 유저입니다 :) 가끔 알고스팟에 이미 푼 문제들에 대한 제 AC submission 들을 한번에 보고 싶은 경우가 있습니다. 그때 마다 항상 유저 프로파일 홈페이지에 AC submission 들을 모아놓은 페이지에 대한 링크가 있었으면 좋겠다.. 생각했었습니다. 그 대신, 매번 특정 문제를 누른 후, 모든 submission 들을 page 를 일일이 뒤저가며 제 AC submission 을 찾곤했는데 어제 @hhjeong 님께서 https://algospot.com/judge/submission/recent/?problem=&user=riceluxs1t&language=&state=6 
와 같이 "최근 제출 된 답안" 페이지에서 필터를 추가해 (state=6) 모아 볼 수 있다는걸 알려주셨습니다. 그리고 profile page 에 "정답 수" 에 해당하는 부분에 링크를 걸면 좋겠다라고 제안해 주셔서 PR 을 만들었습니다.

코드는 이미 Django template 을 사용하고 계셔서 www/base/templates/user_profile.html 에 <a> 태그를 하나 넣었고 태그 주소는 "제출 답안 수" 에 대한 링크를 만들때 사용하는 django template 기능을 그대로 이용하였습니다. (i.e. <a href="{%  url "judge-submission-recent" %}?user={{ profile_user.username }}&state={{ submission_accepted_constant }}">)

사실 "제출 답안 수" 에 대한 링크에다가 &state=6 만 하드코딩해서 넣으면 되긴 하지만, 혹시라도 ACCEPTED 에 대항하는 상수가 6이 아니어 버리는 경우 html 에 하드코딩해 놓으면 찾기 어려울 것 같아서 template 으로 넘겨주는 인자에

"submission_accepted_constant": Submission.ACCEPTED 를 한줄 추가하였습니다.

리뷰 부탁드립니다.


![screen shot 2017-01-18 at 4 05 07 pm](https://cloud.githubusercontent.com/assets/10087079/22085674/b4ed2ae6-dd9a-11e6-836c-87b1fd80ab41.png)

(정답 수 부분에 링크 추가 된 모습)

![screen shot 2017-01-18 at 4 05 30 pm](https://cloud.githubusercontent.com/assets/10087079/22085681/bd1a4b86-dd9a-11e6-98d4-af2637f2b8f4.png)

(링크 누르면 넘어가는 페이지)