### PR TITLE
커멘트가 달렸을 때 글을 지우는 경우 차단

### DIFF
--- a/www/forum/templates/delete.html
+++ b/www/forum/templates/delete.html
@@ -19,7 +19,7 @@
 				<legend>이 글을 정말 삭제하시겠습니까?</legend>
 				{% csrf_token %}
 				<p>
-					<input type="submit" name="submit" value="Delete" class="eng button" /> 혹은 <a href="{% url "forum-read" post.id %}">Cancel</a>
+					<input type="submit" name="submit" value="Delete" class="eng button" /> 혹은 <a href="{% url "forum-read" post.id %}" class="eng button">Cancel</a>
 				</p>
 			</fieldset>
 		</form>

--- a/www/forum/templates/read.html
+++ b/www/forum/templates/read.html
@@ -29,7 +29,11 @@
 							{% if user.is_authenticated %}
 								{% if user.is_superuser or user == post.user %}
 									<a href="{% url "forum-edit" post.id %}" class="button-link">edit</a> 
-									<a href="{% url "forum-delete" post.id %}" class="button-link">delete</a>
+                                    {% if candelete %}
+                                        <a href="{% url "forum-delete" post.id %}" class="button-link">delete</a>
+                                    {% else %}
+                                        <a href="#" class="button-link">delete</a>
+                                    {% endif %} 
 								{% endif %}
 							{% endif %}
 						</span>


### PR DESCRIPTION
회원중에 질문을 올리고 답변을 통해 문제를 해결하고 나서 글을 지워버리는 경우가 빈번하게 발생하고 있습니다. 따라서 이러한 경우를 줄이고자, 댓글이 아예 달리지 않았거나, superuser일 경우에만 글을 지울 수 있도록 수정하였습니다.

PR 확인 부탁합니다.