### PR TITLE
Fix comments count

### DIFF
--- a/www/base/views.py
+++ b/www/base/views.py
@@ -95,7 +95,7 @@ def profile(request, user_id):
     return get_profile(request, user)
 
 def get_profile(request, user):
-    comment_count = Comment.objects.filter(user=user).count()
+    comment_count = Comment.objects.filter(user=user, is_removed=False).count()
     problem_count = Problem.objects.filter(user=user, state=Problem.PUBLISHED).count()
     attempted_problem_count = Solver.objects.filter(user=user).count()
     all_problem_count = Problem.objects.filter(state=Problem.PUBLISHED).count()


### PR DESCRIPTION
#95 에 관한 커밋입니다.
유저 프로필에서 다음과 같은 문제가 있었습니다.
1. 쓴 글 수가 올바르게 나오지 않음
2. 코멘트 수가 삭제한 코멘트까지 포함됨

댓글을 삭제 할 때 `posts`는 차감되는데, `comment_count`는 바뀌지 않아 발생하는 문제인것 같습니다.
`is_removed=False`로 삭제되지 않은 코멘트들의 수만 셈으로써 해결할 수 있습니다.
(개발환경을 세팅하지 못해서 테스트는 못해봤습니다. 😢 꼭 검증해보세요)

그리고, 한 게시물에서 같은 유저가 같은 내용의 코멘트를 달 때 코멘트가 정상적으로 달리지 않고 `posts`가 차감되는 현상이 있습니다. 

https://stackoverflow.com/questions/34237451/same-content-for-same-user-and-same-post-in-django-comments-not-getting-saved

위 답변을 참고하시면 좋을것 같습니다.